### PR TITLE
Improve the search box on iOS

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -119,6 +119,10 @@ body {
   font-weight: 500;
 }
 
+.Locations-search::-webkit-search-decoration {
+  display: none;
+}
+
 .Locations-search:focus {
   box-shadow: 0 0 0 2px rgba(255, 2555, 255, .4);
 }

--- a/src/App.css
+++ b/src/App.css
@@ -107,7 +107,7 @@ body {
   transition: .1s ease-in-out box-shadow;
 
   font-family: inherit;
-  font-size: 1rem;
+  font-size: 1.2rem;
 
   /* Heroicons v2.0.12 by Refactoring UI Inc., used under MIT license */
   background-image: url("data: image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='rgba(255, 2555, 255, .6)' class='w-5 h-5' %3E%3Cpath fill-rule='evenodd' d='M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z' clip-rule='evenodd' /%3E%3C/svg%3E");


### PR DESCRIPTION
# Description

This PR fixes the two following problems on iOS Safari:
* The browser automatically zooms when the search box is selected.
* The browser adds a second search box, which is not necessary since we already add one.

This video shows the old and new behaviors:
<video src="https://user-images.githubusercontent.com/7029582/198724470-c1dabb44-4e18-4b7b-b6fc-fa5a88f6c933.mov">

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:

- Desktop/Mobile: mobile
- OS: iOS 16.0
- Browser: Safari

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
