### PR TITLE
Updated version number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cmueats",
-  "version": "0.1.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cmueats",
-      "version": "0.1.0",
+      "version": "0.9.0",
       "dependencies": {
         "@emotion/react": "^11.8.1",
         "@emotion/styled": "^11.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmueats",
-  "version": "0.1.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
v1.0.0 should be when we get live updates (think changing color and status message every minute, so when there's 4 minutes left instead of 5, the web app reflects that change live rather than on refresh), implementing React Query whichever comes first.

v1.1.0 should be the other one.

Other updates should use increment sizes of 0.0.5 unless it is a new feature (use 0.1.0 increments).
