### PR TITLE
Fix the lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,18 +1,14 @@
-name: Lint and Format
-
-on: [push, pull_request]
+name: Lint
+on: [push]
 
 jobs:
-  workflow:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: bahmutov/npm-install@v1
-      - name: Run Prettier
-        run: npm run format
-        shell: bash
-      - name: Run ESLint Fix
-        run: npm run lint-fix
+      - name: Check TypeScript
+        run: npx tsc
         shell: bash
       - name: Run ESLint
         run: npm run lint


### PR DESCRIPTION
The current CI workflow seems to be broken. It tries to “fix” the linter issues, but the changes are never applied to the repository itself, only on the repo copy used by the action when running. Also, we’re currently not running a TypeScript check. This PR fixes both of these issues.