### PR TITLE
Fixed workflow triggers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: Lint
-on: [push]
+on: [pull_request, push]
 
 jobs:
   lint:

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ coverage
 *.json
 *.config.ts
 *.node.json
+.github


### PR DESCRIPTION
Only having push causes the lint workflow not to be ran on PRs not made from a branch on the main repo. The push trigger event is only ran for branches of the repo (see https://docs.github.com/en/actions/using-workflows/triggering-a-workflow). This is the reason the workflow is triggered for dependabot PRs. Workflows don't run on the main repo on a PR from a fork due to this (see https://github.com/ScottyLabs/cmueats/pull/132 and https://github.com/ScottyLabs/cmueats/pull/133).