### PR TITLE
Fix for locations falsely marked as closed

### DIFF
--- a/src/util/queryLocations.ts
+++ b/src/util/queryLocations.ts
@@ -175,20 +175,27 @@ async function queryLocations() {
 			const mainURL = location.url;
 
 			const updatedTimes = location.times.map(
-				({ start, end }: $TSFixMe) => ({
-					start: {
-						...start,
-						rawMinutes: toMinutes(
-							start.day,
-							start.hour,
-							start.minute,
-						),
-					},
-					end: {
-						...end,
-						rawMinutes: toMinutes(end.day, end.hour, end.minute),
-					},
-				}),
+				({ start, end }: $TSFixMe) => {
+
+					const startRaw = toMinutes(
+						start.day,
+						start.hour,
+						start.minute,
+					);
+					let endRaw = toMinutes(end.day, end.hour, end.minute);
+					if (endRaw < startRaw) endRaw += 7 * 24 * 60; // we end on the next week, so we'll just compensate here by adding a week's worth of minutes
+
+					return {
+						start: {
+							...start,
+							rawMinutes: startRaw,
+						},
+						end: {
+							...end,
+							rawMinutes: endRaw,
+						},
+					}
+				},
 			);
 
 			return {

--- a/src/util/queryLocations.ts
+++ b/src/util/queryLocations.ts
@@ -176,7 +176,6 @@ async function queryLocations() {
 
 			const updatedTimes = location.times.map(
 				({ start, end }: $TSFixMe) => {
-
 					const startRaw = toMinutes(
 						start.day,
 						start.hour,
@@ -194,7 +193,7 @@ async function queryLocations() {
 							...end,
 							rawMinutes: endRaw,
 						},
-					}
+					};
 				},
 			);
 


### PR DESCRIPTION
This site had the Underground (and some other locations) reported as closed even though they was clearly open. Not a problem with the API, but a problem with how Saturday-Sunday times wrap around in the code. (I added an offset to only `rawMinutes` - not sure if that's the best way to fix this or if I need to update the other time fields as well.) 
Example: <img width="581" alt="image" src="https://github.com/ScottyLabs/cmueats/assets/57322506/59e27bc6-2f60-44ff-b5ac-c394395e6834"> 
(endRawMinutes will be 0 here)

Before:
![image](https://github.com/ScottyLabs/cmueats/assets/57322506/f445cdfc-f706-4329-8adb-553e42965c6a)

After:
![image](https://github.com/ScottyLabs/cmueats/assets/57322506/5a772182-d906-4d18-93bc-501fef77b085)
