### PR TITLE
Css improvements 2

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -30,6 +30,6 @@
   "scope": "/",
   "start_url": "/",
   "display": "standalone",
-  "theme_color": "ffffff",
+  "theme_color": "#ffffff",
   "background_color": "#ffffff"
 }

--- a/src/App.css
+++ b/src/App.css
@@ -74,10 +74,23 @@ body {
 }
 
 .Container {
-	padding: 1.5rem 3rem 0;
-	flex-grow: 1;
+	padding: 2.5rem 5rem 0;
+	max-width: 1600px;
+	margin: auto; /*Keep it centered*/
+	width: 100%;
+	box-sizing: border-box;
+	flex: 1;
 }
-
+@media (max-width: 900px) {
+	.Container {
+		padding: 1.3rem;
+	}
+}
+@media (max-width: 800px) {
+	.Container {
+		padding: 1rem;
+	}
+}
 .footer {
 	margin-top: 80px;
 	background-color: #23272a;

--- a/src/App.css
+++ b/src/App.css
@@ -9,6 +9,9 @@ body,
 #root {
 	height: 100%;
 }
+#root {
+	overflow: auto;
+}
 .App {
 	min-height: 100%;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,18 +1,20 @@
 :root {
 	--navbar-height: 70px;
 	--navbar-height: calc(56px + max(env(safe-area-inset-bottom), 14px));
+	--theme-color: #2c2f33;
 }
 
 html,
 body,
-#root,
-.App {
+#root {
 	height: 100%;
 }
-
+.App {
+	min-height: 100%;
+}
 html,
 body {
-	background-color: #2c2f33;
+	background-color: var(--theme-color);
 	margin: 0;
 	padding: 0;
 	font-size: 14px;
@@ -38,59 +40,10 @@ body {
 .App {
 	text-align: left;
 	background-color: #2c2f33;
-	display: flex;
-	flex-direction: column;
+	display: grid;
+	grid-template-rows: 1fr auto;
 }
 
-.App-logo {
-	height: 40vmin;
-	pointer-events: none;
-}
-
-.MainContent {
-	overflow: auto;
-	flex: 1;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-	.App-logo {
-		animation: App-logo-spin infinite 20s linear;
-	}
-}
-
-.App-header {
-	background-color: #282c34;
-	min-height: 100vh;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	font-size: calc(10px + 2vmin);
-	color: white;
-}
-
-.App-link {
-	color: #61dafb;
-}
-
-.Container {
-	padding: 2.5rem 5rem 0;
-	max-width: 1600px;
-	margin: auto; /*Keep it centered*/
-	width: 100%;
-	box-sizing: border-box;
-	flex: 1;
-}
-@media (max-width: 900px) {
-	.Container {
-		padding: 1.3rem;
-	}
-}
-@media (max-width: 800px) {
-	.Container {
-		padding: 1rem;
-	}
-}
 .footer {
 	margin-top: 80px;
 	background-color: #23272a;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,17 @@ import './App.css';
 function App() {
 	// Load locations
 	const [locations, setLocations] = useState([]);
-
+	const [scrollFromTop, setScrolledFromTop] = useState(0);
+	const scrollListener = (event: Event) => {
+		setScrolledFromTop((event.target as HTMLElement).scrollTop);
+	};
+	useEffect(() => {
+		const rootDiv = document.getElementById('root');
+		if (!rootDiv)
+			throw Error('Missing root div! (Why did you rename it lol)');
+		rootDiv.addEventListener('scroll', scrollListener);
+		return () => rootDiv.removeEventListener('scroll', scrollListener);
+	});
 	useEffect(() => {
 		queryLocations().then((parsedLocations: $TSFixMe) => {
 			if (parsedLocations != null) {
@@ -42,7 +52,12 @@ function App() {
 						<Routes>
 							<Route
 								path="/"
-								element={<ListPage locations={locations} />}
+								element={
+									<ListPage
+										locations={locations}
+										scrollFromTop={scrollFromTop}
+									/>
+								}
 							/>
 							<Route
 								path="/map"

--- a/src/components/EateryCard.tsx
+++ b/src/components/EateryCard.tsx
@@ -152,7 +152,7 @@ function EateryCard({ location }: { location: Location }) {
 
 	return (
 		<>
-			<Grid item xs={12} md={4} lg={3} xl={3}>
+			<Grid item xs={1}>
 				<StyledCard>
 					<StyledCardHeader
 						title={

--- a/src/components/Navbar.css
+++ b/src/components/Navbar.css
@@ -4,6 +4,8 @@
 	padding: 14px;
 	box-sizing: border-box;
 	border-top: 2px solid #31373e;
+	position: sticky;
+	bottom: 0;
 }
 
 .Navbar-links {

--- a/src/pages/ListPage.css
+++ b/src/pages/ListPage.css
@@ -30,17 +30,18 @@
 
 	display: flex;
 	flex-wrap: wrap;
-	gap: 2rem;
-	padding: 3rem 0;
+	gap: 1.5rem;
+	padding: 2.5rem 0 1.5rem;
 	place-content: space-between;
 	align-items: end;
+	box-shadow: 0 8px 5px -5px rgb(0 0 0 / 0.4);
 }
 @media (max-width: 900px) {
 	.Locations-container {
 		margin: 1.3rem;
 	}
 	.Locations-header {
-		padding: 1rem 0 2rem;
+		padding: 1rem 0 1.5rem;
 	}
 }
 @media (max-width: 800px) {

--- a/src/pages/ListPage.css
+++ b/src/pages/ListPage.css
@@ -1,7 +1,16 @@
 .ListPage {
-	display: flex;
-	flex-direction: column;
+	display: grid;
+	grid-template-rows: 1fr auto;
 	min-height: 100%; /* So footer (the contact info one) actually stays at the bottom */
+}
+.Locations-container {
+	margin: 2.5rem 5rem 0;
+	max-width: 1600px;
+	justify-self: center;
+	/* Questionable support? Let me know if this is not optimal*/
+	width: -moz-available;
+	width: -webkit-fill-available;
+	width: fill-available;
 }
 
 .badge-accent {
@@ -12,6 +21,12 @@
 }
 
 .Locations-header {
+	isolation: isolate;
+	z-index: 1;
+	position: sticky;
+	top: 0;
+	background-color: var(--theme-color);
+
 	display: flex;
 	flex-wrap: wrap;
 	gap: 2rem;
@@ -19,9 +34,22 @@
 	place-content: space-between;
 	align-items: end;
 }
+@media (max-width: 900px) {
+	.Locations-container {
+		margin: 1.3rem;
+	}
+	.Locations-header {
+		padding: 1rem 0 2rem;
+	}
+}
+@media (max-width: 800px) {
+	.Locations-container {
+		margin: 1rem;
+	}
+}
 .Locations-Greeting {
 	/* This feels a bit hacky but it prevents the search bar from growing too much when the screen gets wide*/
-	flex: 999 max-content;
+	flex: 999 1 max-content;
 	overflow-wrap: break-word;
 	min-width: 0;
 }

--- a/src/pages/ListPage.css
+++ b/src/pages/ListPage.css
@@ -12,21 +12,21 @@
 }
 
 .Locations-header {
-	display: grid;
-	grid-gap: 1rem;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 2rem;
 	padding: 3rem 0;
+	place-content: space-between;
+	align-items: end;
 }
-
-@media screen and (min-width: 900px) {
-	.Locations-header {
-		grid-template-columns: 1fr 300px;
-		align-items: center;
-	}
+.Locations-Greeting {
+	/* This feels a bit hacky but it prevents the search bar from growing too much when the screen gets wide*/
+	flex: 999 max-content;
+	overflow-wrap: break-word;
+	min-width: 0;
 }
 
 .Locations-search {
-	display: block;
-	width: 100%;
 	padding: 0.8rem 1rem;
 	padding-left: 3rem;
 	border-radius: 1rem;
@@ -48,6 +48,9 @@
 
 	color: white;
 	font-weight: 500;
+
+	flex: 1 300px;
+	min-width: 0;
 }
 
 .Locations-search::-webkit-search-decoration {

--- a/src/pages/ListPage.css
+++ b/src/pages/ListPage.css
@@ -21,7 +21,8 @@
 }
 
 .Locations-header {
-	isolation: isolate;
+	isolation: isolate; /* Not necessary, but good practice
+	 											 to show that we've created a new stacking context*/
 	z-index: 1;
 	position: sticky;
 	top: 0;
@@ -48,10 +49,11 @@
 	}
 }
 .Locations-Greeting {
-	/* This feels a bit hacky but it prevents the search bar from growing too much when the screen gets wide*/
+	/* This feels a bit hacky but the flex-grow of 999
+	prevents the search bar from growing too much when the screen gets wide*/
 	flex: 999 1 max-content;
 	overflow-wrap: break-word;
-	min-width: 0;
+	min-width: 0; /* So it keeps shrinking when the screen gets narrow */
 }
 
 .Locations-search {
@@ -78,7 +80,7 @@
 	font-weight: 500;
 
 	flex: 1 300px;
-	min-width: 0;
+	min-width: 0; /* So it keeps shrinking when the screen gets narrow */
 }
 
 .Locations-search::-webkit-search-decoration {

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -136,7 +136,7 @@ function ListPage({ locations }: $TSFixMe) {
 					offline. We apologize for any inconvenience. 🌐🚫
 				</StyledAlert>
 			)}
-			<div className="Container">
+			<div className="Locations-container">
 				<header className="Locations-header">
 					<HeaderText variant="h3" className="Locations-Greeting">
 						{greeting}
@@ -154,7 +154,11 @@ function ListPage({ locations }: $TSFixMe) {
 					<NoResultsError onClear={() => setSearchQuery('')} />
 				)}
 
-				<Grid container spacing={3}>
+				<Grid
+					container
+					spacing={3}
+					columns={{ xs: 1, sm: 2, md: 3, lg: 4 }}
+				>
 					{openLocations
 						.sort(
 							(location1: Location, location2: Location) =>

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -40,7 +40,7 @@ const StyledAlert = styled(Alert)({
 	color: '#ffffff',
 });
 
-function ListPage({ locations }: $TSFixMe) {
+function ListPage({ locations, scrollFromTop }: $TSFixMe) {
 	const greeting = useMemo(() => getGreeting(), []);
 
 	// Search query processing
@@ -117,7 +117,6 @@ function ListPage({ locations }: $TSFixMe) {
 			window.removeEventListener('offline', handleOnlineStatus);
 		};
 	}, []);
-
 	return (
 		<div className="ListPage">
 			{/*  showAlert &&
@@ -137,7 +136,10 @@ function ListPage({ locations }: $TSFixMe) {
 				</StyledAlert>
 			)}
 			<div className="Locations-container">
-				<header className="Locations-header">
+				<header
+					className="Locations-header"
+					style={{ boxShadow: scrollFromTop <= 40 ? 'none' : '' }}
+				>
 					<HeaderText variant="h3" className="Locations-Greeting">
 						{greeting}
 					</HeaderText>
@@ -156,8 +158,9 @@ function ListPage({ locations }: $TSFixMe) {
 
 				<Grid
 					container
-					spacing={3}
+					spacing={2}
 					columns={{ xs: 1, sm: 2, md: 3, lg: 4 }}
+					marginTop={2}
 				>
 					{openLocations
 						.sort(

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -138,7 +138,9 @@ function ListPage({ locations }: $TSFixMe) {
 			)}
 			<div className="Container">
 				<header className="Locations-header">
-					<HeaderText variant="h3">{greeting}</HeaderText>
+					<HeaderText variant="h3" className="Locations-Greeting">
+						{greeting}
+					</HeaderText>
 					<input
 						className="Locations-search"
 						type="search"
@@ -152,7 +154,7 @@ function ListPage({ locations }: $TSFixMe) {
 					<NoResultsError onClear={() => setSearchQuery('')} />
 				)}
 
-				<Grid container spacing={2}>
+				<Grid container spacing={3}>
 					{openLocations
 						.sort(
 							(location1: Location, location2: Location) =>


### PR DESCRIPTION
- Fixed manifest.json theme_color (added # sign)
- Decreased padding on mobile (I added way too much)
- Made search box wrapping dynamic (not based on breakpoints anymore)

If there was too long of a text before it would do this
![Pasted Graphic 11](https://github.com/ScottyLabs/cmueats/assets/57322506/2e6ac3ef-c726-437e-ae65-14f92d201fa6)
But now the search bar will wrap to the next line
![Pasted Graphic 12](https://github.com/ScottyLabs/cmueats/assets/57322506/4dff7adc-a041-44b9-9560-3e032686dc8f)

- Scrolling is actually full-page scroll (rather than just everything-but-bottom-tab scroll) (so mobile browsers can actually detect that the page is taller than screen height - otherwise nav/url bar mide not autohide)
- Header is now sticky (primarily so the search bar is always visible)
- Minor changes to grid breakpoints
- Changed Locations-container padding to margin (but in doing so I had to use -webkit-fill-available to make sure container doesn’t collapse when search results are empty - do let me know if there’s a better way!)
- Removed some React CSS boilerplate
- Added back max-width on Locations-container - any reason why this was reverted in [this commit](https://github.com/ScottyLabs/cmueats/commit/ace8663accc767ddea6587d22a0489137158e2aa)?

Open for feedback!