### PR TITLE
Make search feature search the whole description

### DIFF
--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -77,6 +77,7 @@ function ListPage({
 		// keys to perform the search on
 		keys: ['name', 'location', 'shortDescription'],
 		threshold: 0.3,
+		ignoreLocation: true,
 	};
 
 	const [fuse, setFuse] = useState<Fuse<IReadOnlyExtendedLocation> | null>(


### PR DESCRIPTION
Evelyn pointed out that the search feature on CMUEats doesn't work correctly: for example, the description for Scotty's Market is "International and conventional groceries, savory grilled meats and hot meals," but typing "groceries" in the search bar does not yield any results.

This is because the fuzzy searcher is trying to find a match only at index 0, and is not searching the whole string. Adding the `ignoreLocation` option fixes this issue.

(Note that this does cause a little bit of lag, presumably because the fuzzy searcher is doing more computation. Feel free to test this yourself and please let me know if this is a relevant issue.)