### PR TITLE
Updated search settings to be more accurate/extend search range of sh…

### DIFF
--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -75,8 +75,9 @@ function ListPage({
 	// Fuzzy search options
 	const fuseOptions = {
 		// keys to perform the search on
+		ignoreLocation : true,
 		keys: ['name', 'location', 'shortDescription'],
-		threshold: 0.3,
+		threshold: 0.1,
 	};
 
 	const [fuse, setFuse] = useState<Fuse<IReadOnlyExtendedLocation> | null>(
@@ -99,7 +100,7 @@ function ListPage({
 
 	useLayoutEffect(() => {
 		if (locations === undefined || fuse === null) return;
-		const processedSearchQuery = searchQuery.trim().toLowerCase();
+		const processedSearchQuery = searchQuery.trim().toLowerCase().replace(/[^\w\s]/g, '');
 
 		// Fuzzy search. If there's no search query, it returns all locations.
 		setFilteredLocations(
@@ -290,5 +291,6 @@ function ListPage({
 		</div>
 	);
 }
+
 
 export default ListPage;

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -75,7 +75,7 @@ function ListPage({
 	// Fuzzy search options
 	const fuseOptions = {
 		// keys to perform the search on
-		ignoreLocation : true,
+		ignoreLocation: true,
 		keys: ['name', 'location', 'shortDescription'],
 		threshold: 0.1,
 	};


### PR DESCRIPTION


# Description

Before, searching for words like "groceries" would not work properly (e.g. Scotty's Market wouldn't show up). This was due to the fact that the default location distance was 60, so the search for "groceries" would only be performed on the first 60 characters of the Scotty's Market description. This pull request fixes this issue.

Additionally, the previous threshold of 0.3 meant that "Italian" spots on campus would appear in search results looking for "Asian" because of the similarity of "__alian" and "asian." To avoid this, I lowered the fuzzy search threshold to 0.1

- Bug fix (non-breaking change which fixes an issue)

