### PR TITLE
Map almost closed view

### DIFF
--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -8,7 +8,7 @@ import {
 import { CSSTransition } from 'react-transition-group';
 import EateryCard from '../components/EateryCard';
 import './MapPage.css';
-import { IReadOnlyExtendedLocation } from '../types/locationTypes';
+import { IReadOnlyExtendedLocation, LocationState } from '../types/locationTypes';
 
 const token = process.env.VITE_MAPKITJS_TOKEN;
 
@@ -66,16 +66,23 @@ function MapPage({
 			>
 				{locations.map((location, locationIndex) => {
 					if (!location.coordinates) return undefined;
+					let markerColor = '#ff5b40';
+					if (location.closedLongTerm) {
+						markerColor = '#ff5b40';
+					} else if (
+						location.locationState === LocationState.CLOSES_SOON
+					) {
+						markerColor = '#ffd700';
+					} else if (location.isOpen) {
+						markerColor = '#69bb36';
+					}
+
 					return (
 						<Marker
 							key={location.conceptId}
 							latitude={location.coordinates.lat}
 							longitude={location.coordinates.lng}
-							color={
-								!location.closedLongTerm && location.isOpen
-									? '#69bb36'
-									: '#ff5b40'
-							}
+							color={markerColor}
 							glyphText={abbreviate(location.name)}
 							onSelect={() => {
 								setSelectedLocationIndex(locationIndex);

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -8,7 +8,10 @@ import {
 import { CSSTransition } from 'react-transition-group';
 import EateryCard from '../components/EateryCard';
 import './MapPage.css';
-import { IReadOnlyExtendedLocation, LocationState } from '../types/locationTypes';
+import {
+	IReadOnlyExtendedLocation,
+	LocationState,
+} from '../types/locationTypes';
 
 const token = process.env.VITE_MAPKITJS_TOKEN;
 


### PR DESCRIPTION
# Description

CMU Concept restaurants that close soon are now yellow on the map, and the rest are red and green as usual, depending on if they are open or closed. This way, the list view matches the map. Before, restaurants that appeared yellow on the list were green on the map.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] bun test
- [ ] npm run lint

**Test Configuration**:

- Node.js version: v23.6.1
- Python version: 3.10.9
- OS: MacOS Sonoma 14.6.1
- Browser: Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
