### PR TITLE
Evelyn branch

### DIFF
--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -75,8 +75,9 @@ function ListPage({
 	// Fuzzy search options
 	const fuseOptions = {
 		// keys to perform the search on
+		ignoreLocation : true,
 		keys: ['name', 'location', 'shortDescription'],
-		threshold: 0.3,
+		threshold: 0.1,
 	};
 
 	const [fuse, setFuse] = useState<Fuse<IReadOnlyExtendedLocation> | null>(
@@ -99,7 +100,7 @@ function ListPage({
 
 	useLayoutEffect(() => {
 		if (locations === undefined || fuse === null) return;
-		const processedSearchQuery = searchQuery.trim().toLowerCase();
+		const processedSearchQuery = searchQuery.trim().toLowerCase().replace(/[^\w\s]/g, '');
 
 		// Fuzzy search. If there's no search query, it returns all locations.
 		setFilteredLocations(
@@ -290,5 +291,6 @@ function ListPage({
 		</div>
 	);
 }
+
 
 export default ListPage;

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -75,7 +75,7 @@ function ListPage({
 	// Fuzzy search options
 	const fuseOptions = {
 		// keys to perform the search on
-		ignoreLocation : true,
+		ignoreLocation: true,
 		keys: ['name', 'location', 'shortDescription'],
 		threshold: 0.1,
 	};

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -100,7 +100,7 @@ function ListPage({
 
 	useLayoutEffect(() => {
 		if (locations === undefined || fuse === null) return;
-		const processedSearchQuery = searchQuery.trim().toLowerCase().replace(/[^\w\s]/g, '');
+		const processedSearchQuery = searchQuery.trim().toLowerCase();
 
 		// Fuzzy search. If there's no search query, it returns all locations.
 		setFilteredLocations(


### PR DESCRIPTION
# Description

Searching for certain words (e.g. "groceries") wouldn't work (Scotty's market did not show up) because ignoreLocation was not set to true. Since ignoreLocation wasn't set, the search was only performed on the first 60 characters of shortDesc. 

This version sets ignoreLocation to true, and it also lowers the threshold from 0.3 to 0.1 Previously, the higher threshold meant searching for "Asian" would return restaurants that were described as "Italian" because of the shared letters.

- Bug fix (non-breaking change which fixes an issue)


