### PR TITLE
fix: allow empty special description

### DIFF
--- a/src/types/joiLocationTypes.ts
+++ b/src/types/joiLocationTypes.ts
@@ -15,7 +15,7 @@ const ITimeSlotJoiSchema = Joi.object({
 });
 const ISpecialJoiSchema = Joi.object({
 	title: string.required(),
-	description: string.allow(''),
+	description: string.required().allow(''),
 });
 
 // Note: Keys without .required() are optional by default

--- a/src/types/joiLocationTypes.ts
+++ b/src/types/joiLocationTypes.ts
@@ -15,7 +15,7 @@ const ITimeSlotJoiSchema = Joi.object({
 });
 const ISpecialJoiSchema = Joi.object({
 	title: string.required(),
-	description: string,
+	description: string.allow(''),
 });
 
 // Note: Keys without .required() are optional by default

--- a/src/types/locationTypes.ts
+++ b/src/types/locationTypes.ts
@@ -44,7 +44,7 @@ export type ITimeSlots = ReadonlyArray<ITimeSlot>;
 
 interface ISpecial {
 	title: string;
-	description?: string;
+	description: string;
 }
 
 // Ordered by priority - affects how tiles are displayed in the grid (first to last)


### PR DESCRIPTION
# Description

Joi defaults strings to not accept the empty string. We have no reason to do this, since it's pretty reasonable for a special to possibly only have a title and not a description.

Also, the code (at least the revised backend code in https://github.com/ScottyLabs/dining-api/pull/166) will always return a string for the description.