### PR TITLE
remove VitePWA functionality

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -110,6 +110,7 @@ export default defineConfig(({ command, mode }) => {
                     cleanupOutdatedCaches: true,
                     skipWaiting: true,
                 },
+                selfDestroying: true, // remove previously-registered service worker (if it exists)
             }),
             checker({
                 typescript: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -103,6 +103,7 @@ export default defineConfig(({ command, mode }) => {
             viteTsconfigPaths(),
             svgrPlugin(),
             VitePWA({
+                // WARNING! Removing this library means that all clients with the VitePWA service worker installed *will never have it uninstalled*. (see https://github.com/ScottyLabs/cmueats/pull/642 for more details)
                 manifest: manifestForPlugin,
                 registerType: 'autoUpdate',
                 // Enables autoupdate (uses new version after user quits and reloads app)


### PR DESCRIPTION
Removes VitePWA to get rid of unneeded headaches with offline caching and service worker handling. CMUEats is a web app, not a desktop or mobile app, first of all. (Also, VitePWA isn't even out of beta yet!) (v. 0.21.1 at the time of writing)

Note that _we literally can't remove the plugin_ or else the service worker will never be unregistered and the client's frontend will **never update**. (see https://github.com/vite-pwa/vite-plugin-pwa/issues/281) (I also tested this myself)

If we really wanted to delete vitePWA as a dependency, we can insert a manual snippet to unregister all service workers (eg. https://github.com/vite-pwa/vite-plugin-pwa/issues/217), but for future project hand-off purposes, new tech leads may not be aware that the snippet **must be kept around effectively forever**. If someone hasn't opened cmueats since 2025 and proceeds to do so, the vitePWA service worker will kick back in and serve the same stale content, regardless of what's currently deployed on vercel. (Service Workers are meant to live forever btw: https://stackoverflow.com/questions/75410199/are-service-workers-ever-removed-automatically-by-the-browser)

Thankfully, we can provide a `selfDestroying` argument to vitePWA that does essentially the same thing and may make future developers wary of removing vitePWA in its entirety.

Should close #578 

I suppose the real lesson is to _not add offline app capabilities_ if you really don't need to.

Note: this still preserves the "add webpage as mobile app" ability