### PR TITLE
fix: time sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Note that GitHub will automatically run checks (workflows) on your PR. This incl
 
 Note: To add new dependencies, use `bun add dependency-name`. To remove dependencies, use `bun remove dependency-name`. Run `bun outdated` to see what dependencies are outdated and `bun update` to update all outdated dependencies to the latest version.
 
+## Mocking out the backend
+
+For displaying custom api data without starting up the backend, you can change `BACKEND_LOCATIONS_URL` in `App.tsx` to point to `http://localhost:5173/example-response.json`, which contents should match that returned by the real `/locations` endpoint (note that you need an `example-response.json` file in the /public folder) You can also just modify what's returned by `queryLocations` if that feels more convenient.
+
+(If you're testing this on mobile, be sure to replace `localhost` with your device IP instead.)
+
 ## CSS, the way it was meant to be written™
 
 CMUEats is in the process of transitioning from CSS-in-JS components to pure CSS. Most class names follow the [BEM](https://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/) (Block, Element, Modifier) convention and strongly limit nested selectors (eg. .block-1 .block-2), but some legacy code may not. (PRs to fix these or remove CSS components are strongly encouraged!)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ For displaying custom api data without starting up the backend, you can change `
 https://web.archive.org/web/20250000000000*/https://dining.apis.scottylabs.org/locations
 (Thanks @GhostOf0days)
 
+Archives of the official dining site can be found on https://web.archive.org/web/20250000000000*/https://apps.studentaffairs.cmu.edu/dining/conceptinfo/.
+Individual concept pages are also scraped (ex. https://web.archive.org/web/20250000000000*/https://apps.studentaffairs.cmu.edu/dining/conceptinfo/Concept/113), although accuracy may vary since the dining site sometimes glitches and returns a CLOSED status for a day that has opening times.
+
 ## CSS, the way it was meant to be written™
 
 CMUEats is in the process of transitioning from CSS-in-JS components to pure CSS. Most class names follow the [BEM](https://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/) (Block, Element, Modifier) convention and strongly limit nested selectors (eg. .block-1 .block-2), but some legacy code may not. (PRs to fix these or remove CSS components are strongly encouraged!)

--- a/README.md
+++ b/README.md
@@ -51,9 +51,14 @@ Note: To add new dependencies, use `bun add dependency-name`. To remove dependen
 
 ## Mocking out the backend
 
-For displaying custom api data without starting up the backend, you can change `BACKEND_LOCATIONS_URL` in `App.tsx` to point to `http://localhost:5173/example-response.json`, which contents should match that returned by the real `/locations` endpoint (note that you need an `example-response.json` file in the /public folder) You can also just modify what's returned by `queryLocations` if that feels more convenient.
+For displaying custom api data without starting up the backend, you can change `BACKEND_LOCATIONS_URL` in `App.tsx` to point to `http://localhost:5173/example-response.json`, which contents should match that returned by the real `/locations` endpoint. Feel free to use live or historical data (see below) for reference. (note that you need an `example-response.json` file in the /public folder) You can also just modify what's returned by `queryLocations` if that feels more convenient.
 
 (If you're testing this on mobile, be sure to replace `localhost` with your device IP instead.)
+
+## Accessing historical API data
+
+https://web.archive.org/web/20250000000000*/https://dining.apis.scottylabs.org/locations
+(Thanks @GhostOf0days)
 
 ## CSS, the way it was meant to be written™
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,10 +16,6 @@ import { IReadOnlyLocation_FromAPI_PostProcessed, IReadOnlyLocation_ExtraData_Ma
 import { getPinnedIds, setPinnedIds } from './util/storage';
 import env from './env';
 
-// for debugging purposes (note that you need an example-response.json file in the /public folder)
-// const CMU_EATS_API_URL = 'http://192.168.1.64:5173/example-response.json';
-// for debugging purposes (note that you need an example-response.json file in the /public folder)
-// const CMU_EATS_API_URL = 'http://localhost:5010/locations';
 function App() {
     // Load locations
     const [locations, setLocations] = useState<IReadOnlyLocation_FromAPI_PostProcessed[]>();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,12 +16,14 @@ import { IReadOnlyLocation_FromAPI_PostProcessed, IReadOnlyLocation_ExtraData_Ma
 import { getPinnedIds, setPinnedIds } from './util/storage';
 import env from './env';
 
+const BACKEND_LOCATIONS_URL = `${env.VITE_API_URL}/locations`;
+
 function App() {
     // Load locations
     const [locations, setLocations] = useState<IReadOnlyLocation_FromAPI_PostProcessed[]>();
     const [extraLocationData, setExtraLocationData] = useState<IReadOnlyLocation_ExtraData_Map>();
     useEffect(() => {
-        queryLocations(`${env.VITE_API_URL}/locations`).then((parsedLocations) => {
+        queryLocations(BACKEND_LOCATIONS_URL).then((parsedLocations) => {
             setLocations(parsedLocations);
             setExtraLocationData(getExtraLocationData(parsedLocations, DateTime.now().setZone('America/New_York')));
             // set extended data in same render to keep the two things in sync

--- a/src/pages/EateryCardGrid.tsx
+++ b/src/pages/EateryCardGrid.tsx
@@ -6,6 +6,7 @@ import {
     IReadOnlyLocation_FromAPI_PostProcessed,
     IReadOnlyLocation_ExtraData_Map,
     LocationState,
+    IReadOnlyLocation_Combined,
 } from '../types/locationTypes';
 import assert from '../util/assert';
 
@@ -53,23 +54,22 @@ export default function EateryCardGrid({
 
     if (locations.length === 0) return <NoResultsError onClear={() => setSearchQuery('')} />;
 
-    const compareLocations = (location1: any, location2: any) => {
+    const compareLocations = (location1: IReadOnlyLocation_Combined, location2: IReadOnlyLocation_Combined) => {
         const state1 = location1.locationState;
         const state2 = location2.locationState;
 
         if (state1 !== state2) return state1 - state2;
+
         // this if statement is janky but otherwise TS won't
         // realize that the timeUntil property exists on both l1 and l2
-
         if (location1.closedLongTerm || location2.closedLongTerm) {
             assert(location1.closedLongTerm && location2.closedLongTerm);
             return location1.name.localeCompare(location2.name);
         }
-
-        return (
-            (state1 === LocationState.OPEN || state1 === LocationState.OPENS_SOON ? -1 : 1) *
-            (location1.timeUntil - location2.timeUntil)
-        );
+        if (state1 === LocationState.OPEN || state1 === LocationState.CLOSES_SOON) {
+            return location2.timeUntil - location1.timeUntil;
+        }
+        return location1.timeUntil - location2.timeUntil;
     };
 
     return (

--- a/src/util/queryLocations.ts
+++ b/src/util/queryLocations.ts
@@ -92,7 +92,7 @@ export function getLocationStatus(timeSlots: ITimeRangeList, now: DateTime): IRe
             statusMsg: 'Open 24/7',
             closedLongTerm: false,
             changesSoon: false,
-            timeUntil: 0,
+            timeUntil: Infinity,
             locationState: LocationState.OPEN,
             isOpen: true,
         };

--- a/tests/util/queryLocations.test.ts
+++ b/tests/util/queryLocations.test.ts
@@ -122,7 +122,7 @@ describe('queryLocations.ts', () => {
                 isOpen: true,
                 locationState: LocationState.OPEN,
                 statusMsg: 'Open 24/7',
-                timeUntil: 0,
+                timeUntil: Infinity,
             });
             expect(
                 getLocationStatus(


### PR DESCRIPTION
The sorting order is now
- OPEN (descending time until closing)
- CLOSES_SOON (descending time until closing)
- OPENS_SOON (ascending time until opening)
- CLOSED (ascending time until opening)
- CLOSED_LONG_TERM

which basically preserves existing behaviour while fixing #594. The case can be made that we want whatever closes first to be displayed first, but given that most people are familiar with the old layout (and either layout works, tbh,) I think it's fine keeping it as is.

Stephanie's is now the first card

<img width="2528" height="1063" alt="image" src="https://github.com/user-attachments/assets/bcab8f5b-c5bf-4229-9eb0-6d4b5843a4be" />



