### PR TITLE
fix: search bar fix for safari

### DIFF
--- a/src/components/SearchBar.module.css
+++ b/src/components/SearchBar.module.css
@@ -29,7 +29,7 @@
         display: none;
     }
     &:focus {
-        transition: all 0.5s;
+        transition: all 0.2s;
         box-shadow: 0 0 40px var(--hover-accent-color);
         border-color: var(--hover-accent-color);
         outline: none;
@@ -48,7 +48,7 @@
     color: var(--input-text-placeholder);
     pointer-events: none;
     opacity: 1;
-    transition: opacity 0.3s ease-in;
+    transition: opacity 0.2s ease-in;
 
     kbd {
         border: 1px solid;

--- a/src/components/SearchBar.module.css
+++ b/src/components/SearchBar.module.css
@@ -55,6 +55,12 @@
         border-radius: 5px;
         padding: 0px 3px;
         font-family: monospace;
+        display: inline-flex;
+        .line {
+            width: 1px;
+            margin: 0 4px;
+            background-color: rgba(255, 255, 255, 0.485);
+        }
     }
 }
 

--- a/src/components/SearchBar.module.css
+++ b/src/components/SearchBar.module.css
@@ -59,7 +59,7 @@
         .line {
             width: 1px;
             margin: 0 4px;
-            background-color: rgba(255, 255, 255, 0.485);
+            background-color: rgba(255, 255, 255, 0.285);
         }
     }
 }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -50,17 +50,17 @@ function SearchBar({ searchQuery, setSearchQuery }: { searchQuery: string; setSe
                     <span>
                         Type <kbd>/</kbd> or{' '}
                         {isMac ? (
-                            <span>
-                                <kbd>
-                                    <span>⌘</span>
-                                    <span className={css['line']}></span>
-                                    <span>K</span>
-                                </kbd>
-                            </span>
+                            <kbd>
+                                <span>⌘</span>
+                                <span className={css.line} />
+                                <span>K</span>
+                            </kbd>
                         ) : (
-                            <span>
-                                <kbd>^</kbd> <kbd>K</kbd>
-                            </span>
+                            <kbd>
+                                <span>^</span>
+                                <span className={css.line} />
+                                <span>K</span>
+                            </kbd>
                         )}{' '}
                         to search
                     </span>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -42,7 +42,8 @@ function SearchBar({ searchQuery, setSearchQuery }: { searchQuery: string; setSe
                 type="search"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder=""
+                placeholder=" "
+                // this needs to be nonempty for the :placeholder-shown css to work
             />
             <div className={css['locations-search-hint']}>
                 {isDesktop ? (
@@ -50,11 +51,11 @@ function SearchBar({ searchQuery, setSearchQuery }: { searchQuery: string; setSe
                         Type <kbd>/</kbd> or{' '}
                         {isMac ? (
                             <span>
-                                <kbd>⌘k</kbd>
+                                <kbd>⌘</kbd> <kbd>K</kbd>
                             </span>
                         ) : (
                             <span>
-                                <kbd>^k</kbd>
+                                <kbd>^</kbd> <kbd>K</kbd>
                             </span>
                         )}{' '}
                         to search

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -51,7 +51,11 @@ function SearchBar({ searchQuery, setSearchQuery }: { searchQuery: string; setSe
                         Type <kbd>/</kbd> or{' '}
                         {isMac ? (
                             <span>
-                                <kbd>⌘</kbd> <kbd>K</kbd>
+                                <kbd>
+                                    <span>⌘</span>
+                                    <span className={css['line']}></span>
+                                    <span>K</span>
+                                </kbd>
                             </span>
                         ) : (
                             <span>

--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,7 @@
 
     --input-bg: #23272a;
     --input-text: var(--text-primary);
-    --input-text-placeholder: rgba(255, 255, 255, 0.785);
+    --input-text-placeholder: rgba(255, 255, 255, 0.585);
 
     --card-bg: #23272a;
     --card-header-bg: #1d1f21;


### PR DESCRIPTION
<img width="353" height="80" alt="image" src="https://github.com/user-attachments/assets/44227fac-e6bc-4378-b5b4-bd4d449ab0dd" />

separates the cmd k into two squares, I think it looks better?
closes #694 