### PR TITLE
fix: align card titles

### DIFF
--- a/src/pages/ListPage.css
+++ b/src/pages/ListPage.css
@@ -158,6 +158,9 @@
 }
 .card__header {
     background: var(--card-header-bg);
+    /* @media not screen and (max-width: 900px) {
+        height: 3em;
+    } */
 }
 /* additional .card__header needed to override MUI styles. We can discard when we finish migration */
 .card__header .card__header__text {


### PR DESCRIPTION
Does this look better?

Before:

<img width="735" height="327" alt="Snipaste_2025-09-27_17-46-28" src="https://github.com/user-attachments/assets/dd6c1e08-101a-4e7a-aac1-1008b977143a" />

After:

<img width="739" height="365" alt="Snipaste_2025-09-27_17-46-20" src="https://github.com/user-attachments/assets/32935a33-e69c-49eb-9993-c15d51eabf8f" />
