### PR TITLE
fix #691: Sticky search bar

### DIFF
--- a/src/components/DrawerHeader.module.css
+++ b/src/components/DrawerHeader.module.css
@@ -10,7 +10,7 @@
     justify-content: space-between;
 }
 
-.drawer-loction-text {
+.drawer-location-text {
     font-family: var(--text-primary-font);
     color: var(--text-primary);
     font-size: 2rem;

--- a/src/components/DrawerHeader.tsx
+++ b/src/components/DrawerHeader.tsx
@@ -13,7 +13,7 @@ function DrawerHeader() {
     return (
         <div className={css['drawer-header-container']}>
             <div className={css.header}>
-                <h3 className={css['drawer-loction-text']}>
+                <h3 className={css['drawer-location-text']}>
                     <a className={css['location-link']} href={url} target="_blank" rel="noreferrer">
                         <span>{name}</span>
                         <ExternalLink size={22} strokeWidth={3} aria-hidden />

--- a/src/components/DrawerTabContent.module.css
+++ b/src/components/DrawerTabContent.module.css
@@ -95,7 +95,4 @@
         text-decoration: underline;
     }
 
-    &:hover {
-        text-decoration: underline;
-    }
 }

--- a/src/pages/ListPage.css
+++ b/src/pages/ListPage.css
@@ -19,7 +19,10 @@
     display: flex;
     flex-direction: column;
     padding: 28px 24px 12px;
-    position: relative;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: var(--main-bg);
     @media screen and (max-width: 900px) {
         & {
             padding: 16px 15px 12px;


### PR DESCRIPTION
 **Summary**
- Makes the search bar header sticky so it stays visible when scrolling
- Improves UX especially on mobile where scrolling back up is inconvenient

**Test Plan**
- Tested on desktop (Chrome)
- Tested on mobile device
- Header stays sticky when scrolling
- Cards scroll behind the header correctly       
- Build passes
- TypeScript passes

  Fixes #691