### PR TITLE
fix #697 Fix/map loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,12 @@ function App() {
         queryLocations(BACKEND_LOCATIONS_URL).then(setLocations);
     }, []);
 
+    // Preload MapPage in the background (fixes mobile tap delay)
+    useEffect(() => {
+        import('./pages/MapPage');
+    }, []);
+
+
     useEffect(() => {
         const intervalId = setInterval(() => setNow(DateTime.now().setZone('America/New_York')), 1000);
         return () => clearInterval(intervalId);


### PR DESCRIPTION
Previously, the Map page was unresponsive while MapKit JS initialized, causing users to tap the Map tab multiple times before anything appeared.
Now, a loading fallback shows up immediately, so navigation responds on the first tap and the map loads smoothly in the background.

Fixes #697.