### PR TITLE
Some bug fixes and refactoring for mobile drawer

### DIFF
--- a/src/components/BottomSheet.module.css
+++ b/src/components/BottomSheet.module.css
@@ -5,14 +5,12 @@
     left: 0;
     right: 0;
     bottom: 0;
-    height: 100vh;
     background: var(--black-950);
     border-top-left-radius: 16px;
     border-top-right-radius: 16px;
     box-shadow: 0 -10px 30px black;
     display: flex;
     flex-direction: column;
-    transition: transform 0.3s ease-out;
     border: none;
 }
 

--- a/src/components/BottomSheet.module.css
+++ b/src/components/BottomSheet.module.css
@@ -1,5 +1,5 @@
 .bottomSheet {
-    z-index: 998; /*navbar is at 999 z-index, bottom sheet sits right underneath*/
+    z-index: 1000;
     position: fixed;
     overflow-y: auto;
     left: 0;

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -1,6 +1,5 @@
 import React, { ReactNode, useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import styles from './BottomSheet.module.css';
-import { motion } from 'motion/react';
 
 type BottomSheetProps = {
     children: ReactNode;

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -20,7 +20,11 @@ export default function BottomSheet({ children, onHide, hideSheetDelayMs = 450 }
         historicalClientYPos: [] as { pos: number; time: number }[], // for flick detection
     });
 
-    const [cardY, setCardY] = useState(Math.min(...snapPoints));
+    const [cardY, setCardY] = useState(Math.max(...snapPoints));
+    useEffect(() => {
+        setCardY(Math.min(...snapPoints));
+    }, [snapPoints]);
+
     const [dragging, setDragging] = useState(false);
 
     // hide timeout stuff
@@ -140,14 +144,16 @@ export default function BottomSheet({ children, onHide, hideSheetDelayMs = 450 }
                 />
             )}
 
-            <motion.div
+            <div
                 aria-label="Draggable bottom sheet"
                 role="dialog"
                 aria-modal="true"
                 className={styles.bottomSheet}
-                initial={{ height: 0 }}
-                animate={{ height: `${windowHeight - cardY}px` }}
-                transition={{ duration: dragging ? 0 : hideSheetDelayMs / 1000, ease: [0.22, 1, 0.36, 1] }}
+                style={{
+                    top: cardY,
+                    transition: dragging ? 'none' : `all ${hideSheetDelayMs}ms cubic-bezier(.22,1,.36,1)`,
+                }} // initial={{ height: 0 }}
+                // transition={{ duration: dragging ? 0 : hideSheetDelayMs / 1000, ease: [0.22, 1, 0.36, 1] }}
                 onTouchMove={(ev) => {
                     // starts all drag interaction
                     if (contentRef?.current?.scrollTop === 0) {
@@ -175,7 +181,7 @@ export default function BottomSheet({ children, onHide, hideSheetDelayMs = 450 }
                 >
                     {children}
                 </div>
-            </motion.div>
+            </div>
         </>
     );
 }

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -1,10 +1,10 @@
 import React, { ReactNode, useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import styles from './BottomSheet.module.css';
-import { motion } from 'framer-motion';
+import { motion } from 'motion/react';
 
 type BottomSheetProps = {
     children: ReactNode;
-    onHide?: () => void;
+    onHide: () => void;
     hideSheetDelayMs?: number;
 };
 
@@ -23,17 +23,26 @@ export default function BottomSheet({ children, onHide, hideSheetDelayMs = 450 }
     const [cardY, setCardY] = useState(Math.min(...snapPoints));
     const [dragging, setDragging] = useState(false);
 
+    // hide timeout stuff
     const hideTimeoutRef = useRef<number | null>(null);
     const queueHideCallback = useCallback(() => {
-        if (onHide) {
-            if (hideTimeoutRef.current) {
+        if (hideTimeoutRef.current !== null) {
+            clearTimeout(hideTimeoutRef.current);
+        }
+        hideTimeoutRef.current = window.setTimeout(() => {
+            onHide();
+        }, hideSheetDelayMs);
+    }, [onHide, hideSheetDelayMs]);
+
+    useEffect(() => {
+        // cleanup
+        return () => {
+            if (hideTimeoutRef.current !== null) {
                 clearTimeout(hideTimeoutRef.current);
             }
-            hideTimeoutRef.current = window.setTimeout(() => {
-                onHide();
-            }, hideSheetDelayMs);
-        }
-    }, [onHide, hideSheetDelayMs]);
+        };
+    }, []);
+    // end hide timeout stuff
 
     const startDrag = (ev: React.MouseEvent | React.TouchEvent) => {
         if (dragging) return;

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -1,137 +1,64 @@
-import { ReactNode, useEffect, useRef, useState, useCallback, useMemo } from 'react';
+import React, { ReactNode, useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import styles from './BottomSheet.module.css';
+import { motion } from 'framer-motion';
 
 type BottomSheetProps = {
     children: ReactNode;
-    active: boolean;
     onHide?: () => void;
+    hideSheetDelayMs?: number;
 };
 
-export default function BottomSheet({ children, active, onHide }: BottomSheetProps) {
-    const hideSheetDelay = 100;
-    const windowHeight = window.innerHeight;
-    const FULL = windowHeight * 0.15;
-    const HIDDEN = windowHeight;
+export default function BottomSheet({ children, onHide, hideSheetDelayMs = 450 }: BottomSheetProps) {
+    useGlobalScrollLock();
+    const windowHeight = useWindowHeight();
+    const snapPoints = useMemo(() => [50, windowHeight], [windowHeight]);
 
     const contentRef = useRef<HTMLDivElement | null>(null);
-    const sheetRef = useRef<HTMLDivElement | null>(null);
-    const dragStartTime = useRef(0);
-    const dragStartY = useRef(0);
-    const startY = useRef(0);
-    const startTranslate = useRef(0);
-    const handleRef = useRef<HTMLButtonElement | null>(null);
-    const hideTimeoutRef = useRef<number | null>(null);
-    const activeRef = useRef(active);
+    const dragMetrics = useRef({
+        dragStartY: 0,
+        cardStartY: 0,
+        historicalClientYPos: [] as { pos: number; time: number }[], // for flick detection
+    });
 
-    const [y, setY] = useState(HIDDEN);
+    const [cardY, setCardY] = useState(Math.min(...snapPoints));
     const [dragging, setDragging] = useState(false);
 
-    //stores position of user touch/cursor
-    const [sheetDrag, setSheetDrag] = useState<React.MouseEvent<HTMLElement> | React.TouchEvent<HTMLElement> | null>(
-        null,
-    );
-
-    const snapPoints = useMemo(() => [FULL, HIDDEN], [FULL, HIDDEN]);
-
-    const hide = useCallback(() => {
-        if (y !== HIDDEN) {
-            setY(HIDDEN);
-        }
-
+    const hideTimeoutRef = useRef<number | null>(null);
+    const queueHideCallback = useCallback(() => {
         if (onHide) {
             if (hideTimeoutRef.current) {
                 clearTimeout(hideTimeoutRef.current);
             }
             hideTimeoutRef.current = window.setTimeout(() => {
                 onHide();
-            }, hideSheetDelay);
+            }, hideSheetDelayMs);
         }
-    }, [y, HIDDEN, onHide]);
+    }, [onHide, hideSheetDelayMs]);
 
-    const preventScroll = useCallback((e: Event) => {
-        const target = e.target as HTMLElement;
-
-        if (target.closest('[data-scrollable]') || !activeRef.current) {
-            return;
-        }
-
-        e.preventDefault();
-    }, []);
-
-    const lockScroll = useCallback(() => {
-        document.body.style.overflow = 'hidden';
-
-        document.addEventListener('touchmove', preventScroll, { passive: false });
-        document.addEventListener('wheel', preventScroll, { passive: false });
-    }, [preventScroll]);
-
-    const unlockScroll = useCallback(() => {
-        document.body.style.overflow = 'visible';
-
-        document.removeEventListener('touchmove', preventScroll);
-        document.removeEventListener('wheel', preventScroll);
-    }, [preventScroll]);
-
-    const startDrag = useCallback(
-        (e: React.MouseEvent<HTMLElement> | React.TouchEvent<HTMLElement>) => {
-            setDragging(true);
-
-            const clientY =
-                'touches' in e && e.touches.length > 0 ? e.touches[0]!.clientY : 'clientY' in e ? e.clientY : 0;
-
-            startY.current = clientY;
-            startTranslate.current = y;
-
-            dragStartTime.current = performance.now();
-            dragStartY.current = clientY;
-        },
-        [y],
-    );
-
-    const onSheetScroll = useCallback(() => {
-        if (contentRef?.current?.scrollTop === 0 && sheetDrag && !dragging) {
-            startDrag(sheetDrag);
-        }
-    }, [sheetDrag, startDrag, dragging]);
-
-    const startSheetDrag = (e: React.MouseEvent<HTMLElement> | React.TouchEvent<HTMLElement>) => {
-        if (dragging) {
-            return;
-        }
-
-        //user mouse/touch stored to allow smooth transition between scrolling and dragging
-        setSheetDrag(e);
-
-        //starts sheet dragging if user is scrolling past the top of the sheet contents
-        contentRef?.current?.addEventListener('scroll', onSheetScroll);
-
-        if (contentRef?.current?.scrollTop === 0) {
-            startDrag(e);
-        }
+    const startDrag = (ev: React.MouseEvent | React.TouchEvent) => {
+        if (dragging) return;
+        setDragging(true);
+        const cursorY = getYPos(ev);
+        dragMetrics.current = {
+            dragStartY: cursorY,
+            cardStartY: cardY,
+            historicalClientYPos: [{ pos: cursorY, time: performance.now() }],
+        };
     };
-
-    const endSheetDrag = () => {
-        contentRef?.current?.removeEventListener('scroll', onSheetScroll);
-    };
-
-    const startHandleDrag = (e: React.MouseEvent<HTMLElement> | React.TouchEvent<HTMLElement>) => {
-        if (contentRef?.current?.scrollTop) {
-            startDrag(e);
-        }
-    };
-
     const onDrag = useCallback(
         (e: MouseEvent | TouchEvent) => {
-            if (!dragging) return;
+            const clientY = getYPos(e);
+            const minSnapPoint = Math.min(...snapPoints);
+            const maxSnapPoint = Math.max(...snapPoints);
+            const newYPos = Math.max(
+                minSnapPoint,
+                Math.min(dragMetrics.current.cardStartY + (clientY - dragMetrics.current.dragStartY), maxSnapPoint),
+            );
+            dragMetrics.current.historicalClientYPos.push({ pos: clientY, time: performance.now() });
 
-            const clientY =
-                'touches' in e && e.touches.length > 0 ? e.touches[0]!.clientY : 'clientY' in e ? e.clientY : 0;
-
-            const next = Math.max(FULL, Math.min(startTranslate.current + (clientY - startY.current), HIDDEN));
-
-            setY(next);
+            setCardY(newYPos);
         },
-        [dragging, setY, FULL, HIDDEN],
+        [snapPoints],
     );
 
     const onDragEnd = useCallback(
@@ -139,138 +66,158 @@ export default function BottomSheet({ children, active, onHide }: BottomSheetPro
             if (!dragging) return;
 
             setDragging(false);
-
-            const clientY =
+            const minSnapPoint = Math.min(...snapPoints);
+            const maxSnapPoint = Math.max(...snapPoints);
+            const endClientY =
                 'changedTouches' in e && e.changedTouches.length > 0
                     ? e.changedTouches[0]!.clientY
                     : 'clientY' in e
                       ? e.clientY
-                      : startY.current;
-
-            const endTime = performance.now();
-            const dt = endTime - dragStartTime.current;
-            const dy = clientY - dragStartY.current;
-
-            const velocity = dy / dt;
-            const FLICK_THRESHOLD = 0.6;
+                      : 0; // cannot call getPosY because finger is no longer on the screen
+            const endSheetY = Math.max(
+                minSnapPoint,
+                Math.min(dragMetrics.current.cardStartY + (endClientY - dragMetrics.current.dragStartY), maxSnapPoint),
+            );
+            dragMetrics.current.historicalClientYPos.push({
+                pos: endClientY,
+                time: performance.now(),
+            });
 
             let target: number;
-
-            if (Math.abs(velocity) > FLICK_THRESHOLD) {
-                if (velocity > 0) {
-                    target = snapPoints.find((p) => p > y) ?? HIDDEN;
+            const flickVelocity = getVelocity(dragMetrics.current.historicalClientYPos);
+            if (Math.abs(flickVelocity) > 0.3) {
+                if (flickVelocity > 0) {
+                    target = snapPoints.find((p) => p >= endSheetY)!;
                 } else {
-                    target = [...snapPoints].reverse().find((p) => p < y) ?? FULL;
+                    target = [...snapPoints].reverse().find((p) => p <= endSheetY)!;
                 }
             } else {
-                target = snapPoints.reduce((a, b) => (Math.abs(b - y) < Math.abs(a - y) ? b : a));
+                target = snapPoints.reduce((a, b) => (Math.abs(b - endSheetY) < Math.abs(a - endSheetY) ? b : a));
             }
 
-            setY(target);
+            setCardY(target);
 
-            if (target === HIDDEN) {
-                hide();
+            if (target === maxSnapPoint) {
+                queueHideCallback();
             }
         },
-        [dragging, setDragging, snapPoints, HIDDEN, FULL, y, hide],
+        [dragging, snapPoints, queueHideCallback],
     );
 
+    // if dragging, starts calculating sheet position (moves sheet)
     useEffect(() => {
-        activeRef.current = active;
-        if (active) {
-            lockScroll();
-            setY(FULL);
-        } else {
-            unlockScroll();
-        }
-    }, [active, FULL, HIDDEN, lockScroll, unlockScroll]);
+        if (!dragging) return; // dragging is initiated by `startDrag`
+        const controller = new AbortController();
 
-    //if dragging, starts calculating sheet position (moves sheet)
-    useEffect(() => {
-        if (contentRef.current) {
-            contentRef.current.style.overflow = y <= FULL ? 'auto' : 'hidden';
-        }
+        window.addEventListener('mousemove', onDrag, { signal: controller.signal });
+        window.addEventListener('mouseup', onDragEnd, { signal: controller.signal });
+        window.addEventListener('touchmove', onDrag, { signal: controller.signal });
+        window.addEventListener('touchend', onDragEnd, { signal: controller.signal });
 
-        window.addEventListener('mousemove', onDrag);
-        window.addEventListener('mouseup', onDragEnd);
-        window.addEventListener('touchmove', onDrag);
-        window.addEventListener('touchend', onDragEnd);
-
-        return () => {
-            window.removeEventListener('mousemove', onDrag);
-            window.removeEventListener('mouseup', onDragEnd);
-            window.removeEventListener('touchmove', onDrag);
-            window.removeEventListener('touchend', onDragEnd);
-        };
-    }, [dragging, y, snapPoints, FULL, HIDDEN, hide, onDragEnd, onDrag]);
-
-    //cleanup
-    useEffect(() => {
-        activeRef.current = active;
-        return () => {
-            if (hideTimeoutRef.current) {
-                clearTimeout(hideTimeoutRef.current);
-            }
-            unlockScroll();
-        };
-    }, [active, unlockScroll]);
+        return () => controller.abort(); // clean up event listeners
+    }, [dragging, onDragEnd, onDrag]);
 
     return (
         <>
-            {active && y !== HIDDEN && (
-                <button className={`${styles.dim}`} onClick={hide} aria-label="Close bottom sheet" type="button" />
-            )}
-
-            {active && (
-                // oxlint-disable-next-line no-static-element-interactions
-                <div
-                    onMouseMove={startSheetDrag}
-                    onMouseUp={endSheetDrag}
-                    onTouchMove={startSheetDrag}
-                    onTouchEnd={endSheetDrag}
-                    onKeyDown={(e) => {
-                        if (e.key === 'Escape') hide();
+            {cardY !== Math.max(...snapPoints) && (
+                <button
+                    className={`${styles.dim}`}
+                    onClick={() => {
+                        setCardY(Math.max(...snapPoints));
+                        queueHideCallback();
                     }}
-                    aria-label="Draggable bottom sheet"
-                    style={{ outline: 'none' }}
-                >
-                    <div
-                        ref={sheetRef}
-                        role="dialog"
-                        aria-modal="true"
-                        className={styles.bottomSheet}
-                        style={{
-                            transform: `translateY(${y}px)`,
-                            transition: dragging ? 'none' : 'transform 500ms cubic-bezier(0.22, 1, 0.36, 1)',
-                        }}
-                    >
-                        <button
-                            type="button"
-                            aria-label="Bottom sheet handle"
-                            ref={handleRef}
-                            className={styles.handleContainer}
-                            onMouseDown={startHandleDrag}
-                            onTouchStart={startHandleDrag}
-                        >
-                            <div className={styles.handle} />
-                        </button>
-
-                        <div
-                            data-scrollable
-                            id="bottom-sheet-content"
-                            className={styles.content}
-                            ref={contentRef}
-                            style={{
-                                height: `calc(100vh - ${y}px - 41px)`, // 41px = handle
-                                overflowY: 'auto',
-                            }}
-                        >
-                            {children}
-                            <div className={styles.navbarPadding} />
-                        </div>
-                    </div>
-                </div>
+                    aria-label="Close bottom sheet"
+                    type="button"
+                />
             )}
+
+            <motion.div
+                aria-label="Draggable bottom sheet"
+                role="dialog"
+                aria-modal="true"
+                className={styles.bottomSheet}
+                initial={{ height: 0 }}
+                animate={{ height: `${windowHeight - cardY}px` }}
+                transition={{ duration: dragging ? 0 : hideSheetDelayMs / 1000, ease: [0.22, 1, 0.36, 1] }}
+                onTouchMove={(ev) => {
+                    // starts all drag interaction
+                    if (contentRef?.current?.scrollTop === 0) {
+                        startDrag(ev);
+                    }
+                }}
+            >
+                <button
+                    type="button"
+                    aria-label="Bottom sheet handle"
+                    className={styles.handleContainer}
+                    onMouseMove={(ev) => {
+                        if (ev.buttons & 1) startDrag(ev); // left-click drag
+                    }}
+                >
+                    <div className={styles.handle} />
+                </button>
+
+                <div
+                    data-scrollable
+                    id="bottom-sheet-content"
+                    className={styles.content}
+                    ref={contentRef}
+                    style={{ overflow: cardY > Math.min(...snapPoints) ? 'hidden' : 'auto' }}
+                >
+                    {children}
+                </div>
+            </motion.div>
         </>
     );
+}
+function getYPos(ev: MouseEvent | TouchEvent | React.MouseEvent | React.TouchEvent) {
+    // event listeners use the first two, while element callbacks use the latter two...
+    return 'touches' in ev && ev.touches.length > 0 ? ev.touches[0]!.clientY : 'clientY' in ev ? ev.clientY : 0;
+}
+
+/**
+ *
+ * @param dragEvents Timestamped positions accumulated during drag
+ * @returns approximate final velocity, for flick detection purposes
+ */
+function getVelocity(dragEvents: { pos: number; time: number }[]) {
+    if (dragEvents.length < 2) return 0;
+    const latestPos = dragEvents[dragEvents.length - 1]!;
+    const earlierPos = dragEvents.find((ev) => ev.time >= latestPos.time - 300)!;
+    if (earlierPos.time === latestPos.time) return 0;
+    const velocity = (latestPos.pos - earlierPos.pos) / (latestPos.time - earlierPos.time);
+    return velocity;
+}
+function useGlobalScrollLock() {
+    useEffect(() => {
+        const abortController = new AbortController();
+        document.body.style.overflow = 'hidden';
+
+        const preventScroll = (e: Event) => {
+            const target = e.target as HTMLElement;
+
+            if (target.closest('[data-scrollable]')) {
+                return;
+            }
+
+            e.preventDefault();
+        };
+        document.addEventListener('touchmove', preventScroll, { passive: false, signal: abortController.signal });
+        document.addEventListener('wheel', preventScroll, { passive: false, signal: abortController.signal });
+        return () => {
+            document.body.style.overflow = 'visible';
+            abortController.abort();
+        };
+    }, []);
+}
+function useWindowHeight() {
+    const [windowHeight, setWindowHeight] = useState(window.innerHeight);
+    useEffect(() => {
+        const onWindowResize = () => {
+            setWindowHeight(window.innerHeight);
+        };
+        window.addEventListener('resize', onWindowResize);
+        return () => window.removeEventListener('resize', onWindowResize);
+    }, []);
+    return windowHeight;
 }

--- a/src/components/Drawer.module.css
+++ b/src/components/Drawer.module.css
@@ -9,17 +9,6 @@
     scrollbar-width: thin;
     background-color: var(--black-950);
     container-type: inline-size;
-
-    @media screen and (max-width: 900px) {
-        & {
-            --drawer-width: 100%;
-            --drawer-x-padding: 15px;
-
-            position: fixed;
-            overflow-y: auto;
-            inset: 0;
-        }
-    }
 }
 
 .drawer-enter {

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -41,7 +41,7 @@ function Drawer({ locations }: { locations: ILocation_Full[] | undefined }) {
     useEffect(() => {
         drawerRef.current?.scrollTo({ top: 0, behavior: 'instant' });
     }, [pickedLocation?.id]);
-    if (pickedLocation === undefined) return;
+    if (pickedLocation === undefined) return null;
     return isMobile ? (
         <BottomSheet onHide={closeDrawer}>
             <div className={css['drawer-box-mobile']} ref={drawerRef}>

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -41,9 +41,9 @@ function Drawer({ locations }: { locations: ILocation_Full[] | undefined }) {
     useEffect(() => {
         drawerRef.current?.scrollTo({ top: 0, behavior: 'instant' });
     }, [pickedLocation?.id]);
-
+    if (pickedLocation === undefined) return;
     return isMobile ? (
-        <BottomSheet active={pickedLocation !== undefined} onHide={closeDrawer}>
+        <BottomSheet onHide={closeDrawer}>
             <div className={css['drawer-box-mobile']} ref={drawerRef}>
                 {pickedLocation !== undefined && (
                     <WidthContext.Provider value={drawerWidth}>
@@ -58,23 +58,21 @@ function Drawer({ locations }: { locations: ILocation_Full[] | undefined }) {
         </BottomSheet>
     ) : (
         <AnimatePresence mode="popLayout">
-            {pickedLocation !== undefined && (
-                <motion.div
-                    initial={{ opacity: 0, transform: 'translateX(3px)' }}
-                    animate={{ opacity: 1, transform: 'translateX(0)', transition: { delay: 0.04 } }} // it just feels right lmao
-                    exit={{ opacity: 0, transition: { duration: 0 } }} // hard transition cut so back swipe gesture on mobile isn't jank (can remove once we add the actual mobile drawer)
-                    className={css['drawer-box']}
-                    ref={drawerRef}
-                >
-                    <WidthContext.Provider value={drawerWidth}>
-                        <DrawerTabsContextProvider location={pickedLocation} key={pickedLocation.id}>
-                            <DrawerHeader />
-                            <DrawerTabNav />
-                            <DrawerTabContent />
-                        </DrawerTabsContextProvider>
-                    </WidthContext.Provider>
-                </motion.div>
-            )}
+            <motion.div
+                initial={{ opacity: 0, transform: 'translateX(3px)' }}
+                animate={{ opacity: 1, transform: 'translateX(0)', transition: { delay: 0.04 } }} // it just feels right lmao
+                exit={{ opacity: 0, transition: { duration: 0 } }} // hard transition cut so back swipe gesture on mobile isn't jank (can remove once we add the actual mobile drawer)
+                className={css['drawer-box']}
+                ref={drawerRef}
+            >
+                <WidthContext.Provider value={drawerWidth}>
+                    <DrawerTabsContextProvider location={pickedLocation} key={pickedLocation.id}>
+                        <DrawerHeader />
+                        <DrawerTabNav />
+                        <DrawerTabContent />
+                    </DrawerTabsContextProvider>
+                </WidthContext.Provider>
+            </motion.div>
         </AnimatePresence>
     );
 }

--- a/src/components/DrawerHeader.module.css
+++ b/src/components/DrawerHeader.module.css
@@ -75,7 +75,7 @@
     gap: 5px;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 900px) {
     .drawer-header-container {
         padding: 0px var(--drawer-x-padding) 20px;
     }

--- a/src/contexts/IsMobileContext.tsx
+++ b/src/contexts/IsMobileContext.tsx
@@ -3,10 +3,10 @@ import { createContext, useContext, useState, useEffect } from 'react';
 const isMobileContext = createContext<boolean | undefined>(undefined);
 
 export function IsMobileContextProvider({ children }: { children: React.ReactNode }) {
-    const [isMobile, setIsMobile] = useState(window.innerWidth <= 980);
+    const [isMobile, setIsMobile] = useState(window.innerWidth <= 900);
     useEffect(() => {
         const handleResize = () => {
-            setIsMobile(window.innerWidth <= 980);
+            setIsMobile(window.innerWidth <= 900);
         };
 
         window.addEventListener('resize', handleResize);

--- a/src/contexts/IsMobileContext.tsx
+++ b/src/contexts/IsMobileContext.tsx
@@ -4,7 +4,6 @@ const isMobileContext = createContext<boolean | undefined>(undefined);
 
 export function IsMobileContextProvider({ children }: { children: React.ReactNode }) {
     const [isMobile, setIsMobile] = useState(window.innerWidth <= 600);
-
     useEffect(() => {
         const handleResize = () => {
             setIsMobile(window.innerWidth <= 600);

--- a/src/contexts/IsMobileContext.tsx
+++ b/src/contexts/IsMobileContext.tsx
@@ -3,10 +3,10 @@ import { createContext, useContext, useState, useEffect } from 'react';
 const isMobileContext = createContext<boolean | undefined>(undefined);
 
 export function IsMobileContextProvider({ children }: { children: React.ReactNode }) {
-    const [isMobile, setIsMobile] = useState(window.innerWidth <= 600);
+    const [isMobile, setIsMobile] = useState(window.innerWidth <= 980);
     useEffect(() => {
         const handleResize = () => {
-            setIsMobile(window.innerWidth <= 600);
+            setIsMobile(window.innerWidth <= 980);
         };
 
         window.addEventListener('resize', handleResize);


### PR DESCRIPTION
- Fixes jittering on panel scroll -> panel drag down transition (probably has to do with caching the `sheetDrag` event, which I removed)
- Removes some BottomSheet state
- Some hook extraction and grouping of drag information in the `dragMetrics` ref variable.
- window.innerHeight now updates on window resize (it doesn't re-clamp the drawer though, might be necessary...)
- Drawer now also usable on narrow desktop screens
Before: (note that I don't even have my mouse down in the recording)

https://github.com/user-attachments/assets/94dd3fdf-0e18-4233-b44d-bdab846714e7

- You can still flick-to-close now even if you pause for a long time after initiating drag
- The large `window.addEventListener` hook doesn't get called every time the sheet y position changes.