### PR TITLE
fix: overflow hide the selector instead of the entire row

### DIFF
--- a/src/components/SelectDropdown.module.css
+++ b/src/components/SelectDropdown.module.css
@@ -28,6 +28,7 @@
 }
 
 .select {
+    overflow: hidden;
     position: absolute;
     inset: 0;
     opacity: 0;

--- a/src/pages/ListPage.css
+++ b/src/pages/ListPage.css
@@ -17,8 +17,6 @@
     }
     overflow-y: auto;
     height: 100%;
-    /* keep sticky list-controls-container under iOS overlay scrollbars */
-    isolation: isolate;
 }
 
 .list-controls-container {
@@ -27,7 +25,6 @@
     z-index: 727;
     background-color: var(--black-950);
     margin-bottom: 10px;
-    overflow-y: hidden;
 }
 .list-controls-layout {
     margin-left: auto;


### PR DESCRIPTION
Fixes background shadow clipping

before:
<img width="595" height="273" alt="image" src="https://github.com/user-attachments/assets/0d473f5a-26de-46fc-80b7-07305350e8c1" />

after:
<img width="874" height="199" alt="image" src="https://github.com/user-attachments/assets/8155490e-fc5c-40d9-a4ed-2f1315d65521" />
