### PR TITLE
fix: searchbar drops chars due to rerender

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -8,14 +8,18 @@ function SearchBar({ searchQuery, setSearchQuery }: { searchQuery: string; setSe
 
     // delay query to prevent performance issue
     const [pendingQuery, setPendingQuery] = useState(searchQuery);
+    const lastSentRef = useRef(searchQuery);
     useEffect(() => {
-        setPendingQuery(searchQuery);
+        if (searchQuery !== lastSentRef.current) {
+            setPendingQuery(searchQuery);
+        }
     }, [searchQuery]);
     useEffect(() => {
         if (pendingQuery === searchQuery) {
             return () => {};
         }
         const timeoutId = window.setTimeout(() => {
+            lastSentRef.current = pendingQuery;
             setSearchQuery(pendingQuery);
         }, 150);
         return () => window.clearTimeout(timeoutId);

--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -4,17 +4,17 @@
  * @returns the same string, but in title case (single characters aren't upper-cased)
  */
 export default function toTitleCase(str: string) {
-  return str
-    .trim()
-    .toLowerCase()
-    .split(" ")
-    .map((word) => {
-      if (word === "ii") return "II"; // special case
-      if (word === "c") return "C"; // In Market C, the C should be capitalized
-      if (word.length > 1) {
-        return word[0]!.toUpperCase() + word.slice(1);
-      }
-      return word;
-    })
-    .join(" ");
+    return str
+        .trim()
+        .toLowerCase()
+        .split(' ')
+        .map((word) => {
+            if (word === 'ii') return 'II'; // special case
+            if (word === 'c') return 'C'; // In Market C, the C should be capitalized
+            if (word.length > 1) {
+                return word[0]!.toUpperCase() + word.slice(1);
+            }
+            return word;
+        })
+        .join(' ');
 }


### PR DESCRIPTION
Previously, after the user typing a new search string, searchQuery in the parent will update the search string and cause the useEffect's to reset pendingQuery, and drops chars. So instead, we compare searchQuery against the last value we sent, so internal debounce updates are ignored.